### PR TITLE
don't ouptut enrolled json escaped to avoid possible parsing issues (…

### DIFF
--- a/ziti-enroller/subcmd/root.go
+++ b/ziti-enroller/subcmd/root.go
@@ -134,7 +134,10 @@ func processEnrollment() error {
 		return fmt.Errorf("failed to open file '%s': %s", outpath, err.Error())
 	}
 
-	encErr := json.NewEncoder(output).Encode(&conf)
+	enc := json.NewEncoder(output)
+	enc.SetEscapeHTML(false)
+	encErr := enc.Encode(&conf)
+
 	if encErr == nil {
 		fmt.Printf("enrolled successfully. identity file written to: %s", outpath)
 		return nil


### PR DESCRIPTION
Right now json output is escaped meaning ampersands are output as \u0026. That is currently causing heartache in the c sdk. This proposal will output the enrollment without that escaping...

Any worries about this patch?