### PR TITLE
don't  configure root command with PersistentPostRun, because it does…

### DIFF
--- a/ziti-tunnel/cmd/ziti-tunnel/subcmd/root.go
+++ b/ziti-tunnel/cmd/ziti-tunnel/subcmd/root.go
@@ -45,10 +45,9 @@ func init() {
 }
 
 var root = &cobra.Command{
-	Use:               filepath.Base(os.Args[0]),
-	Short:             "Ziti Tunnel",
-	PersistentPreRun:  rootPreRun,
-	PersistentPostRun: rootPostRun,
+	Use:              filepath.Base(os.Args[0]),
+	Short:            "Ziti Tunnel",
+	PersistentPreRun: rootPreRun,
 }
 
 var interceptor intercept.Interceptor

--- a/ziti-tunnel/cmd/ziti-tunnel/subcmd/run.go
+++ b/ziti-tunnel/cmd/ziti-tunnel/subcmd/run.go
@@ -19,19 +19,20 @@
 package subcmd
 
 import (
+	"github.com/michaelquigley/pfxlog"
 	"github.com/netfoundry/ziti-edge/tunnel/intercept"
 	"github.com/netfoundry/ziti-edge/tunnel/intercept/tproxy"
 	"github.com/netfoundry/ziti-edge/tunnel/intercept/tun"
-	"github.com/michaelquigley/pfxlog"
 	"github.com/spf13/cobra"
 )
 
 var runCmd = &cobra.Command{
-	Use:   "run <config>",
-	Short: "Auto-select interceptor",
-	Long:  "Provided for backwards compatibility with scripts that were coded around older ziti-tunnel versions.",
-	Args:  cobra.MaximumNArgs(1),
-	Run:   run,
+	Use:     "run <config>",
+	Short:   "Auto-select interceptor",
+	Long:    "Provided for backwards compatibility with scripts that were coded around older ziti-tunnel versions.",
+	Args:    cobra.MaximumNArgs(1),
+	Run:     run,
+	PostRun: rootPostRun,
 }
 
 func init() {


### PR DESCRIPTION
Sorry for the double PR. Now I see why PersistenPostRun was removed from the root command. 

- don't configure root command with PersistentPostRun, since it doesn't apply for all subcommands (e.g. "version).
- do configure run subcommand with PostRun, because it needs to happen there.