### PR TITLE
update deps for netfoundry/ziti-edge#158

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -1,3 +1,13 @@
+# Release 0.14.3
+## Theme
+Ziti 0.14.3 includes the following:
+  * Fixes for orphaned enrollments/authenticators post identity PUT
+
+## Orphaned Enrollments/Authenticators
+When updating an identity via PUT it was possible to clear the authenticators and enrollments associated with the identity making
+it impossible to authenticate as that identity or complete enrollment. This release removes failed enrollments, associates orphaned
+authenticators with their target identities, addresses the root cause, and adds regression tests.
+
 # Release 0.14.2
 ## Theme
 Ziti 0.14.2 includes the following:

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/keybase/go-ps v0.0.0-20190827175125-91aafc93ba19
 	github.com/michaelquigley/pfxlog v0.0.0-20190813191113-2be43bd0dccc
-	github.com/netfoundry/ziti-edge v0.14.15
+	github.com/netfoundry/ziti-edge v0.14.16
 	github.com/netfoundry/ziti-fabric v0.11.31
 	github.com/netfoundry/ziti-foundation v0.9.17
 	github.com/netfoundry/ziti-sdk-golang v0.11.33

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/netfoundry/secretstream v0.1.1 h1:z6T7B5DuOtr9O+SmKaS9DzwOoGLYtgvyTzuPuR5FO7I=
 github.com/netfoundry/secretstream v0.1.1/go.mod h1:uasYkYSp0MmNSlKOWJ2sVzxPms8e58TS4ENq4yro86k=
-github.com/netfoundry/ziti-edge v0.14.15 h1:f1Oa+S/gn4AjnQ0Ju2PTxXFG9p3mcyw6LpfwumBnda0=
-github.com/netfoundry/ziti-edge v0.14.15/go.mod h1:5Akv539VhL33jhgKCfrp6DKvXpR+SjsSVFf7FVXLUIM=
+github.com/netfoundry/ziti-edge v0.14.16 h1:kCylOoiKCVJpvw+riuoAD0Jfwk8ZfFUWIg60RX/b0Tc=
+github.com/netfoundry/ziti-edge v0.14.16/go.mod h1:5Akv539VhL33jhgKCfrp6DKvXpR+SjsSVFf7FVXLUIM=
 github.com/netfoundry/ziti-fabric v0.11.31 h1:otjhKFvxBLJUDP06lHnDOsHwkvVDp3xdhKK/EQyb+Ek=
 github.com/netfoundry/ziti-fabric v0.11.31/go.mod h1:OkTL8ftDbnWv9BBOGZB5cfOGUOwHz3VF9+dyxBJhHfo=
 github.com/netfoundry/ziti-foundation v0.9.17 h1:cBI8oeeZLbZad4nCUe/fjad02h5es4tjbAA9qJID1Bs=


### PR DESCRIPTION
- fixes for identity update
- migration to fix orphaned enrollments/authenticators